### PR TITLE
Restrict reivew

### DIFF
--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -5,6 +5,18 @@
   </div>
 </div>
 
+<!-- THIS LOGIC BELOW IS NEEDED
+      IT PREVENTS USERS FROM EDITING AND DESTROYING
+      ENTRIES THAT AREN'T THEIRS -->
+<% if policy(@course).edit? %>
+  <%= link_to "EDIT ME", edit_course_path(@course), class:"btn btn-warning" %>
+  <br>
+  <br>
+  <%= link_to "Delete Course?", course_path(@course), method: :delete, class:"btn btn-danger"%>
+<% end %>
+
+<!-- Please intergrate the above into the COURSE card -->
+
 <div class="container course">
   <div class="row py-5">
     <div class="col-lg-8 col-md-12">
@@ -13,6 +25,8 @@
       <p class="duration"><i class="fas fa-clock"></i> <%= @course.duration %></p>
       <p class="description mt-3"><%= @course.description %></p>
       <div class="reviews-container border-top py-4">
+  <!-- REVIEW SECTION BELOW -->
+        <% if !policy(@course).edit? %>
         <h3>Review this course</h3>
         <% @course.reviews.each do |review| %>
         <p>Stars: <%=review.stars%>, Content: <%=review.content%><p>
@@ -25,6 +39,7 @@
           <% end %>
         </div>
       </div>
+      <% end %>
     </div>
     <div class="col-lg-4 col-md-12">
       <div class="form-container">
@@ -44,13 +59,3 @@
   data-mapbox-api-key="<%= ENV['MAPBOX_API_KEY'] %>"
 ></div>
 
-
-<!-- THIS LOGIC BELOW IS NEEDED
-      IT PREVENTS USERS FROM EDITING AND DESTROYING
-      ENTRIES THAT AREN'T THEIRS -->
-<% if policy(@course).edit? %>
-  <%= link_to "EDIT ME", edit_course_path(@course), class:"btn btn-warning" %>
-  <br>
-  <br>
-  <%= link_to "Delete Course?", course_path(@course), method: :delete, class:"btn btn-danger"%>
-<% end %>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -49,8 +49,8 @@
       IT PREVENTS USERS FROM EDITING AND DESTROYING
       ENTRIES THAT AREN'T THEIRS -->
 <% if policy(@course).edit? %>
-  <%= link_to "EDIT ME", edit_course_path(@course) %>
+  <%= link_to "EDIT ME", edit_course_path(@course), class:"btn btn-warning" %>
   <br>
   <br>
-  <%= link_to "Delete Course?", course_path(@course), method: :delete %>
+  <%= link_to "Delete Course?", course_path(@course), method: :delete, class:"btn btn-danger"%>
 <% end %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
-ActiveRecord::Schema.define(version: 2019_08_15_070538) do
+ActiveRecord::Schema.define(version: 2019_08_15_145441) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,6 +38,7 @@ ActiveRecord::Schema.define(version: 2019_08_15_070538) do
     t.float "latitude"
     t.float "longitude"
     t.string "location"
+    t.integer "price"
     t.index ["user_id"], name: "index_courses_on_user_id"
   end
 


### PR DESCRIPTION
I fixed it so that we can have a EDIT / DELETE button on a course's show page OR we can have a REVIEW form but NEVER both. 

The lack of a review currently really upsets the mini-styling we have on the page. I image that once the main card styling is done, the review's width not being their to fill it out won't matter. But it may be a good idea to push the review to its on CSS container - Possibly put it under the booking section. 