### PR TITLE
I added a redirect to the desired course for a failed booking create.

### DIFF
--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -39,7 +39,7 @@ class BookingsController < ApplicationController
     if @booking.save
       redirect_to booking_path(@booking)
     else
-      render :new
+      redirect_to course_path(@booking.course)
     end
   end
 


### PR DESCRIPTION
The solution was to just add a redirect to the course page rather than render the new form. 

We may want to ask ourselves if we even need the "new" path now that it is done inside the course page. Also ask ourselves what requirements we want to have for this. 

If we want to pass the registration form data (like the data you tried to enter but failed with) we will need to ask DOUG how to use "render" for this purpose. I am not sure it is possible. 

We may also wish to figure out how we convey to the person trying to make a booking WHY it failed and even make it clear THAT it failed. Perhaps on a separate NEW-BOOKING page we could do this. 